### PR TITLE
修复window平台文件路径反斜杠上传失败

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,8 @@ async function start(dirPath, envPath) {
     let progress = 0
     await Promise.all(
       files.map(async file_path => {
-        const name = file_path.replace(DIST_DIR + path.sep, '')
+        file_path=file_path.replace(/\\/g,'/')
+        const name = file_path.replace(DIST_DIR.replace(/\\/g,'/') + '/', '')
         await client.put(name, file_path)
         progress += progress_per_file
         log(`=========== 已完成${progress}% ===========`)


### PR DESCRIPTION
window平台中，文件地址分隔符为\，导致文件上传失败